### PR TITLE
Net::Statsd::Timer->finish returns elapsed milliseconds

### DIFF
--- a/lib/Net/Statsd/Client.pm
+++ b/lib/Net/Statsd/Client.pm
@@ -106,7 +106,8 @@ __END__
 
     my $timer = $stats->timer("request_duration");
     # ... do something expensive ...
-    $timer->finish;
+    my $elapsed_ms = $timer->finish;
+
 
 =head1 ATTRIBUTES
 
@@ -160,7 +161,8 @@ Record an event of duration C<$time> milliseconds for the named timing metric.
 
 Returns a L<Net::Statsd::Client::Timer> object for the named timing metric.
 The timer begins when you call this method, and ends when you call C<finish>
-on the timer.
+on the timer.  Calling C<finish> on the timer returns the elapsed time in
+milliseconds.
 
 =head2 $stats->gauge($metric, $value, [$sample_rate])
 

--- a/lib/Net/Statsd/Client/Timer.pm
+++ b/lib/Net/Statsd/Client/Timer.pm
@@ -33,13 +33,14 @@ sub BUILD {
 
 sub finish {
   my ($self) = @_;
-  my $duration = tv_interval($self->{start});
+  my $duration = tv_interval($self->{start}) * 1000;
   $self->{statsd}->timing_ms(
     $self->{metric},
-    $duration * 1000,
+    $duration,
     $self->{sample_rate},
   );
   delete $self->{_pending};
+  return $duration;
 }
 
 sub cancel {
@@ -90,7 +91,7 @@ begins counting as soon as it's constructed.
 
 =head2 $timer->finish
 
-Stop timing, and send the elapsed time to the server.
+Stop timing, and send the elapsed time to the server.  Returns the elapsed time in milliseconds.
 
 =head2 $timer->cancel
 

--- a/t/timer.t
+++ b/t/timer.t
@@ -7,6 +7,7 @@ use lib "$FindBin::Bin/lib";
 
 use Test::More;
 use TestStatsd;
+use Time::HiRes qw(sleep);
 
 use_ok 'Net::Statsd::Client';
 
@@ -22,5 +23,11 @@ sends_ok {
   $timer->metric("bar");
   $timer->finish;
 } $client, qr/bar/, "changed metric";
+
+# Test that the timer returns the milliseconds
+my $timer = $client->timer('foo');
+sleep 0.1;
+my $elapsed_ms = $timer->finish;
+ok( $elapsed_ms > 100, "timer->finish returned elapsed ms");
 
 done_testing;


### PR DESCRIPTION
Since we're tracking how long things take, we might as well share that
information with our caller.  This might be helpful if the programmer
wishes to take an action if the elapsed time falls within a certain
range.  It's a convenience option only.