### PR TITLE
Add sampling everywhere, or not

### DIFF
--- a/lib/Net/Statsd/Client.pm
+++ b/lib/Net/Statsd/Client.pm
@@ -68,23 +68,27 @@ sub update {
 sub timing_ms {
   my ($self, $metric, $time, $sample_rate) = @_;
   $metric = "$self->{prefix}$metric";
+  $sample_rate = $self->{sample_rate} unless defined $sample_rate;
   $self->{statsd}->timing($metric, $time, $sample_rate);
 }
 
 sub gauge {
   my ($self, $metric, $value, $sample_rate) = @_;
   $metric = "$self->{prefix}$metric";
+  $sample_rate = $self->{sample_rate} unless defined $sample_rate;
   $self->{statsd}->send({ $metric => "$value|g" }, $sample_rate);
 }
 
 sub set_add {
   my ($self, $metric, $value, $sample_rate) = @_;
   $metric = "$self->{prefix}$metric";
+  $sample_rate = $self->{sample_rate} unless defined $sample_rate;
   $self->{statsd}->send({ $metric => "$value|s" }, $sample_rate);
 }
 
 sub timer {
   my ($self, $metric, $sample_rate) = @_;
+  $sample_rate = $self->{sample_rate} unless defined $sample_rate;
 
   return Net::Statsd::Client::Timer->new(
     statsd => $self,

--- a/lib/Net/Statsd/Client/Timer.pm
+++ b/lib/Net/Statsd/Client/Timer.pm
@@ -18,7 +18,7 @@ has '_pending' => (
   default => quote_sub q{1},
 );
 
-has ['metric', 'start', '_file', '_line', 'warning_callback'] => (
+has ['metric', 'start', '_file', '_line', 'warning_callback', 'sample_rate'] => (
   is => 'rw',
 );
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -25,17 +25,17 @@ sends_ok {
 
 $client = Net::Statsd::Client->new(sample_rate => 0.42);
 
-sends_ok { $client->increment("foo1") } $client, qr/^foo1:1\|c\|\@0.42$/, "increment sampled";
-sends_ok { $client->decrement("foo2") } $client, qr/^foo2:-1\|c\|\@0.42$/, "decrement sampled";
-sends_ok { $client->update("foo3", 42) } $client, qr/^foo3:42\|c\|\@0.42$/, "update sampled";
-sends_ok { $client->timing_ms("foo4", 1) } $client, qr/^foo4:1\|ms$/, "timing sampled (no suffix)";
+sends_ok { $client->increment("foo1") } $client, qr/^foo1:1\|c\|\@0\.42$/, "increment sampled";
+sends_ok { $client->decrement("foo2") } $client, qr/^foo2:-1\|c\|\@0\.42$/, "decrement sampled";
+sends_ok { $client->update("foo3", 42) } $client, qr/^foo3:42\|c\|\@0\.42$/, "update sampled";
+sends_ok { $client->timing_ms("foo4", 1) } $client, qr/^foo4:1\|ms\|\@0\.42$/, "timing sampled";
 sends_ok {
   my $timer = $client->timer("foo5");
   sleep 1;
   $timer->finish;
-} $client, qr/^foo5:[\d\.]+\|ms$/, "timer 2 sampled (no suffix)";
+} $client, qr/^foo5:[\d\.]+\|ms\|\@0\.42$/, "timer 2 sampled";
 
-sends_ok { $client->gauge("luftballons", 99) } $client, qr/^luftballons:99\|g$/, "gauge";
-sends_ok { $client->set_add("users", "gary") } $client, qr/^users:gary\|s$/, "set";
+sends_ok { $client->gauge("luftballons", 99) } $client, qr/^luftballons:99\|g\|\@0\.42$/, "gauge";
+sends_ok { $client->set_add("users", "gary") } $client, qr/^users:gary\|s\|\@0\.42$/, "set";
 
 done_testing;

--- a/t/live.t
+++ b/t/live.t
@@ -58,14 +58,14 @@ $client = Net::Statsd::Client->new(sample_rate => 0.42);
 sends_ok { $client->increment("foo1") } qr/^foo1:1\|c\|\@0.42$/, "increment sampled";
 sends_ok { $client->decrement("foo2") } qr/^foo2:-1\|c\|\@0.42$/, "decrement sampled";
 sends_ok { $client->update("foo3", 42) } qr/^foo3:42\|c\|\@0.42$/, "update sampled";
-sends_ok { $client->timing_ms("foo4", 1) } qr/^foo4:1\|ms$/, "timing sampled (no suffix)";
+sends_ok { $client->timing_ms("foo4", 1) } qr/^foo4:1\|ms\|\@0.42$/, "timing sampled";
 sends_ok {
   my $timer = $client->timer("foo5");
   sleep 1;
   $timer->finish;
-} qr/^foo5:[\d\.]+\|ms$/, "timer 2 sampled (no suffix)";
+} qr/^foo5:[\d\.]+\|ms\|\@0.42$/, "timer 2 sampled (no suffix)";
 
-sends_ok { $client->gauge("luftballons", 99) } qr/^luftballons:99\|g$/, "gauge";
-sends_ok { $client->set_add("users", "gary") } qr/^users:gary\|s$/, "set";
+sends_ok { $client->gauge("luftballons", 99) } qr/^luftballons:99\|g\|\@0.42$/, "gauge";
+sends_ok { $client->set_add("users", "gary") } qr/^users:gary\|s\|\@0.42$/, "set";
 
 done_testing;

--- a/t/live.t
+++ b/t/live.t
@@ -55,17 +55,17 @@ sends_ok {
 
 $client = Net::Statsd::Client->new(sample_rate => 0.42);
 
-sends_ok { $client->increment("foo1") } qr/^foo1:1\|c\|\@0.42$/, "increment sampled";
-sends_ok { $client->decrement("foo2") } qr/^foo2:-1\|c\|\@0.42$/, "decrement sampled";
-sends_ok { $client->update("foo3", 42) } qr/^foo3:42\|c\|\@0.42$/, "update sampled";
-sends_ok { $client->timing_ms("foo4", 1) } qr/^foo4:1\|ms\|\@0.42$/, "timing sampled";
+sends_ok { $client->increment("foo1") } qr/^foo1:1\|c\|\@0\.42$/, "increment sampled";
+sends_ok { $client->decrement("foo2") } qr/^foo2:-1\|c\|\@0\.42$/, "decrement sampled";
+sends_ok { $client->update("foo3", 42) } qr/^foo3:42\|c\|\@0\.42$/, "update sampled";
+sends_ok { $client->timing_ms("foo4", 1) } qr/^foo4:1\|ms\|\@0\.42$/, "timing sampled";
 sends_ok {
   my $timer = $client->timer("foo5");
   sleep 1;
   $timer->finish;
-} qr/^foo5:[\d\.]+\|ms\|\@0.42$/, "timer 2 sampled (no suffix)";
+} qr/^foo5:[\d\.]+\|ms\|\@0\.42$/, "timer 2 sampled";
 
-sends_ok { $client->gauge("luftballons", 99) } qr/^luftballons:99\|g\|\@0.42$/, "gauge";
-sends_ok { $client->set_add("users", "gary") } qr/^users:gary\|s\|\@0.42$/, "set";
+sends_ok { $client->gauge("luftballons", 99) } qr/^luftballons:99\|g\|\@0\.42$/, "gauge";
+sends_ok { $client->set_add("users", "gary") } qr/^users:gary\|s\|\@0\.42$/, "set";
 
 done_testing;


### PR DESCRIPTION
Hi,

i can't open an issue there, so i will explain the "issue" within the pull request.

In the documentation of the module, each method is taking a parameter sample_rate, to do rating.
When "forcing" that parameter in the method call (increment, decrement, update, gauge or timeing_ms) , the metrics that is outpue is suffixed with |@0.5 (if sample rate is 0.5)

However, when setting the default sample_rate at the client level, in the constructor, only increment and decrement are sampled.

There's a strange inconsistency there, as the default value for sampling is ignored and does not sample for timing_ms for instance, but sampling can be forced.
If timing_ms does not support sampling, we should probably not allow to force the sampling in the function call, if it does support, i don't get why the default value does not apply.

Another issue is in the timer method, in that one, neither the default value, nor the "forced" one is taken into account, reason being, in time, we create a time object like that:

```perl
  return Net::Statsd::Client::Timer->new(
    statsd => $self,
    metric => $metric,
    sample_rate => $sample_rate,
    warning_callback => $self->warning_callback,
  );
```

But the class Net::Statsd::Client::Timer does not have any attribute sample_rate to store that sampling rate.

In the merge request, i added sampling everywhere, the other alternative would be to remove all the sampling from timings, gauges, sets, ... and keep it only on increment and decrement